### PR TITLE
feat: adding custom commit pattern option

### DIFF
--- a/scripts/bb-validate-commits.sh
+++ b/scripts/bb-validate-commits.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo '{"user":"'$(echo $BB_TOKEN_BASIC_AUTH | sed -rn 's/:.+//p')'","password":"'$(echo $BB_TOKEN_BASIC_AUTH | sed -rn 's/.+://p')'","workspace":"'$BITBUCKET_REPO_OWNER'"}' > bitbucket-ext.json
+COMMIT_PATTERN=$(npx bitbucket-ext get-project-info $BITBUCKET_REPO_SLUG | jq .description | sed -rn 's/COMMIT_PATTERN: (.+)/\1/p' | sed -e 's/^"//' -e 's/"$//' || echo)
+if [[ $COMMIT_PATTERN = '' ]]; then
+  COMMIT_PATTERN='(fix|feat|perf|revert):'
+fi
+rm -rf bitbucket-ext.json
+COMMITS=$(if [[ $(git log $BITBUCKET_PR_DESTINATION_BRANCH.. | grep -E $COMMIT_PATTERN) = '' ]]; then echo 0; else echo 1; fi)
+
+if [[ $COMMITS = '0' ]]; then echo 'No changes were found! Pattern '$COMMIT_PATTERN; exit 1; fi

--- a/scripts/bb-validate-hotfix.sh
+++ b/scripts/bb-validate-hotfix.sh
@@ -2,9 +2,7 @@
 
 echo Validating commit against $BITBUCKET_PR_DESTINATION_BRANCH
 git fetch origin $BITBUCKET_PR_DESTINATION_BRANCH:$BITBUCKET_PR_DESTINATION_BRANCH
-COMMITS=$(if [[ $(git log $BITBUCKET_PR_DESTINATION_BRANCH.. | grep -E '(fix|feat|perf|revert):') = '' ]]; then echo 0; else echo 1; fi)
-
-if [[ $COMMITS = '0' ]]; then echo 'No changes were found!'; exit 1; fi
+. ./scripts/bb-validate-commits.sh
 
 CHANGELOG=$(if [[ $(git diff $BITBUCKET_PR_DESTINATION_BRANCH.. --stat | grep -E 'CHANGELOG.+\|') = '' ]]; then echo 0; else echo 1; fi)
 

--- a/scripts/bb-validate-release.sh
+++ b/scripts/bb-validate-release.sh
@@ -4,8 +4,7 @@ echo Validating commit against $BITBUCKET_PR_DESTINATION_BRANCH
 git fetch origin $BITBUCKET_PR_DESTINATION_BRANCH:$BITBUCKET_PR_DESTINATION_BRANCH
 
 if [[ $BITBUCKET_PR_DESTINATION_BRANCH = master ]]; then
-  COMMITS=$(if [[ $(git log $BITBUCKET_PR_DESTINATION_BRANCH.. | grep -E '(fix|feat|perf|revert):') = '' ]]; then echo 0; else echo 1; fi)
-  if [[ $COMMITS = '0' ]]; then echo 'No changes were found!'; exit 1; fi
+  . ./scripts/bb-validate-commits.sh
 fi
 
 CHANGELOG=$(if [[ $(git diff $BITBUCKET_PR_DESTINATION_BRANCH.. --stat | grep -E 'CHANGELOG.+\|') = '' ]]; then echo 0; else echo 1; fi)


### PR DESCRIPTION
Adding option to specify custom commit pattern by bitbucket project

This will allow for each project to be its own commit rules.
To specify it, you need to insert a line in the project description like this:

COMMIT_PATTERN: (fix|feat): .+ [\w+]

If such line is found during commit validation, it will be used against the current commits to see if a valid message was found